### PR TITLE
ci: Update GitHub Actions to Latest Version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Check spelling with codespell
-        uses: codespell-project/actions-codespell@v1
+        uses: codespell-project/actions-codespell@v2.1
         with:
           check_filenames: true
           check_hidden: true
@@ -25,14 +25,14 @@ jobs:
           path: "*.tex **/*.tex **/**/*.tex"
 
       - name: Compile LaTeX document
-        uses: xu-cheng/latex-action@v3
+        uses: xu-cheng/latex-action@3.2.0
         with:
           working_directory: "."
           root_file: |
             main.tex
 
       - name: Upload PDF file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: PDF
           path: main.pdf


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[xu-cheng/latex-action](https://github.com/xu-cheng/latex-action)** published a new release **[3.2.0](https://github.com/xu-cheng/latex-action/releases/tag/3.2.0)** on 2024-03-16T09:12:58Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.6.2](https://github.com/actions/upload-artifact/releases/tag/v4.6.2)** on 2025-03-19T17:47:02Z
* **[codespell-project/actions-codespell](https://github.com/codespell-project/actions-codespell)** published a new release **[v2.1](https://github.com/codespell-project/actions-codespell/releases/tag/v2.1)** on 2024-08-18T23:50:42Z
